### PR TITLE
fix(a11y): give the map container a real accessible name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 === Draad Kaarten ===
 Tested up to: 6.8
-Stable tag: 1.4.2
+Stable tag: 1.4.3
 Requires PHP: 8.0
 Plugin voor het maken van kaarten met OpenStreetMaps
 
@@ -11,6 +11,10 @@ Voeg vervolgens locaties met vrij invulbare tegels toe aan de kaart.
 Of voeg een dataset toe met grenzen of markers.
 
 ## Changelog
+
+### 1.4.3
+
+- Fixed the map container having no accessible name: the label was rendered as `data-draad-aria-label`, which screen readers ignore. It is now a real `aria-label` on a `role="region"` container
 
 ### 1.4.2
 

--- a/draad-kaarten.php
+++ b/draad-kaarten.php
@@ -4,7 +4,7 @@
  * Plugin Name: Draad Kaarten
  * Description: Draad Kaarten laat je makkelijk kaarten toevoegen aan je website doormiddel van een shortcode of gutenberg blok.
  * text-domain: draad-kaarten
- * Version: 1.4.2
+ * Version: 1.4.3
  */
 
 include_once 'includes/helper.php';
@@ -23,7 +23,7 @@ if ( !defined( 'DRAAD_MAPS_PATH' ) ) {
 }
 
 if ( !defined( 'DRAAD_KAARTEN_VERSIE' ) ) {
-    define( 'DRAAD_KAARTEN_VERSIE', '1.4.2' );
+    define( 'DRAAD_KAARTEN_VERSIE', '1.4.3' );
 }
 
 /**

--- a/includes/renderer.php
+++ b/includes/renderer.php
@@ -430,8 +430,12 @@ if ( ! function_exists( 'draad_maps_renderer' ) ) {
             && isset( $center['zoom'], $center['coordinates']['lat'], $center['coordinates']['lng'] ) ) {
             $args['center'] = $center['zoom'] . '/' . $center['coordinates']['lat'] . '/' . $center['coordinates']['lng'];
         }
-        $args['aria-label'] = $post->post_title;
-        $attributes         = '';
+        // A real aria-label, not data-draad-aria-label: the loop below prefixes
+        // every $args key, and screen readers ignore the data- attribute. role=region
+        // is required with it — the container is a role-less div (Leaflet only adds
+        // tabindex), and aria-label on a generic element is not exposed.
+        $attributes = ' role="region" aria-label="'
+            . esc_attr( sprintf( __( 'Kaart %s', 'draad-kaarten' ), $post->post_title ) ) . '"';
 
         if ( is_iterable( $args ) ) {
             foreach ( $args as $key => $value ) {


### PR DESCRIPTION
Fixes axe Auditor issue 24915 on denhaag.nl (WCAG 2.2 AA, 4.1.2.a Name, Role, Value — Moderate, recurring on multiple pages).

## Problem

`includes/renderer.php` funnelled the label through the generic `$args` loop, so it rendered as `data-draad-aria-label="…"` — a non-existent ARIA attribute that screen readers ignore entirely. Nothing in `src/js/draad-maps.js` ever read it.

```html
<div class="draad-maps" data-draad-map="113561" data-draad-aria-label="Milieuzone en Zero-Emissiezone" tabindex="0">
```

## Fix

A real `aria-label` (escaped — the data loop never escaped its values) on a `role="region"` container. The role is required: the container is a role-less `div` that Leaflet only makes focusable with `tabindex="0"`, and `aria-label` on a generic element is not exposed to AT, so the auditor's bare `aria-label` recommendation would leave it half-fixed. `region` over `application`, which hijacks screen-reader browse mode.

One render site, so every map on the site is covered.

## Verified

On `https://maps.test/plattegronden-en-parkeerkosten/`:

```html
<div class="draad-maps leaflet-container …" role="region" aria-label="Kaart Plattegronden en parkeerkosten" data-draad-map="117" tabindex="0">
```

Accessibility tree: `region "Kaart Plattegronden en parkeerkosten"`. `php -l` clean.

Version bumped 1.4.2 → 1.4.3 with the changelog entry.